### PR TITLE
Don't add Data.Functor.unzip to Prelude

### DIFF
--- a/library/StrictList/Prelude.hs
+++ b/library/StrictList/Prelude.hs
@@ -26,7 +26,7 @@ import Data.Either as Exports
 import Data.Fixed as Exports
 import Data.Foldable as Exports hiding (toList)
 import Data.Function as Exports hiding (id, (.))
-import Data.Functor as Exports
+import Data.Functor as Exports hiding (unzip)
 import Data.Functor.Alt as Exports hiding (many, optional, some, ($>))
 import Data.Functor.Bind as Exports hiding (($>))
 import Data.Functor.Extend as Exports


### PR DESCRIPTION
This avoids a name conflict introduced in base-4.19 (GHC 9.8) with the introduction of Data.Functor.unzip, which is a more general variant of the function with the same name in Prelude.

Let me know if you have any thoughts.