### PR TITLE
Hide Data.List.List from Prelude import 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/library/StrictList/Prelude.hs
+++ b/library/StrictList/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 module StrictList.Prelude
   ( module Exports,
   )

--- a/library/StrictList/Prelude.hs
+++ b/library/StrictList/Prelude.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module StrictList.Prelude
   ( module Exports,
   )
@@ -36,7 +37,11 @@ import Data.Hashable as Exports (Hashable)
 import Data.IORef as Exports
 import Data.Int as Exports
 import Data.Ix as Exports
+#if MIN_VERSION_base(4,20,0)
 import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons, unzip)
+#else
+import Data.List as Exports hiding (List, all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons, unzip)
+#endif
 import Data.Maybe as Exports
 import Data.Monoid as Exports hiding (Alt, First (..), Last (..), (<>))
 import Data.Ord as Exports


### PR DESCRIPTION
This PR hides the `Data.List.List` identifier from the Data.List import in Prelude.hs.

Since the identifier will arrive with [base-4.20.0.0](https://gitlab.haskell.org/ghc/ghc/-/blob/2776920e642544477a38d0ed9205d4f0b48a782e/libraries/base/changelog.md#42000-tba), this hiding is guarded behind a CPP conditional.